### PR TITLE
Fixes jungle station holomap generation

### DIFF
--- a/code/modules/html_interface/map/station_map.dm
+++ b/code/modules/html_interface/map/station_map.dm
@@ -56,10 +56,12 @@
 
 	//Station Holomaps display the map of the Z-Level they were built on.
 	generateStationMinimap(map.zMainStation)
-	if(world.maxz >= map.zAsteroid)
+	if((map.zAsteroid > 0) && (world.maxz >= map.zAsteroid))
 		generateStationMinimap(map.zAsteroid)
-	if(world.maxz >= map.zDerelict)
+	if((map.zDerelict > 0) && (world.maxz >= map.zDerelict))
 		generateStationMinimap(map.zDerelict)
+	if((map.zAdditionalStationZlevel > 0) && (world.maxz >= map.zAdditionalStationZlevel))
+		generateStationMinimap(map.zAdditionalStationZlevel)
 	//If they were built on another Z-Level, they will display an error screen.
 
 	holomaps_initialized = 1
@@ -187,7 +189,7 @@
 		full_obstacles += /obj/structure/flora/tree
 
 	if(!map.disable_holominimap_generation)
-		if (zLevel > map.zDeepSpace)
+		if (zLevel > map.highest_z_level)
 			return // No need to generate an holomap for something that didn't spawn.
 		if(zLevel != map.zCentcomm)
 			for(var/i = 1 to ((2 * world.view + 1)*WORLD_ICON_SIZE))

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -33,6 +33,7 @@
 	var/zDeepSpace = 6
 
 	var/zAdditionalStationZlevel = -1 // -1 because surely nothing will ever go to Z -1, right? why not null? because nullspace
+	var/highest_z_level = 6
 
 	var/skip_hobo_shack = FALSE // if true, skips hobo shack generation. set to TRUE if you want to map your own custom one for the map.
 
@@ -107,6 +108,17 @@
 
 /datum/map/New()
 	. = ..()
+
+	var/zDeepSpace = 6
+
+	highest_z_level = max(
+		zMainStation,
+		zCentcomm,
+		zTCommSat,
+		zDerelict,
+		zAsteroid,
+		zDeepSpace,
+		zAdditionalStationZlevel)
 
 	src.loadZLevels(src.zLevels)
 

--- a/maps/_map.dm
+++ b/maps/_map.dm
@@ -109,8 +109,6 @@
 /datum/map/New()
 	. = ..()
 
-	var/zDeepSpace = 6
-
 	highest_z_level = max(
 		zMainStation,
 		zCentcomm,

--- a/maps/junglestation.dm
+++ b/maps/junglestation.dm
@@ -36,8 +36,8 @@
 	skip_hobo_shack=TRUE
 	can_enlarge=FALSE
 
-	holomap_offset_x = list(80,0,0,86,4,0,0,)
-	holomap_offset_y = list(50,0,0,94,10,0,0,)
+	holomap_offset_x = list(80,80,0,86,4,0,0,)
+	holomap_offset_y = list(50,50,0,94,10,0,0,)
 
 	center_x = 182
 	center_y = 163


### PR DESCRIPTION
<img width="1582" height="582" alt="image" src="https://github.com/user-attachments/assets/2aaab184-3e25-4f64-a7f5-b87f3053a973" />
not perfect but at least walls appear. Edit vault area vars to ensure they don't appear on the holomaps.